### PR TITLE
Allow API to not be dependent on Evaluate until Evaluate api call is made

### DIFF
--- a/sail_on/api/evaluate/activity_recognition.py
+++ b/sail_on/api/evaluate/activity_recognition.py
@@ -1,9 +1,6 @@
 """Activity Recognition Class for metrics for sail-on."""
 
 from .metrics import ProgramMetrics
-from evaluate.metrics import M_acc, M_num, M_ndp, M_num_stats
-from evaluate.metrics import M_ndp_failed_reaction
-from evaluate.metrics import M_accuracy_on_novel
 
 import numpy as np
 from pandas import DataFrame
@@ -64,6 +61,8 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing top1, top3 accuracy over the test, pre and post novelty.
         """
+        from evaluate.metrics import M_acc
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_acc(
@@ -79,6 +78,7 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Difference between the novelty introduction and predicting change in world.
         """
+        from evaluate.metrics import M_num
         return M_num(p_novel, gt_novel)
 
     def m_num_stats(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -90,6 +90,7 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing indices for novelty introduction and change in world prediction.
         """
+        from evaluate.metrics import M_num_stats
         return M_num_stats(p_novel, gt_novel)
 
     def m_ndp(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -101,6 +102,7 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing novelty detection performance over the test.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="full_test")
 
     def m_ndp_pre(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -112,6 +114,7 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance pre novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="pre_novelty")
 
     def m_ndp_post(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -123,6 +126,7 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance post novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="post_novelty")
 
     def m_ndp_failed_reaction(
@@ -142,6 +146,8 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing TP, FP, TN, FN, top1, top3 accuracy over the test.
         """
+        from evaluate.metrics import M_ndp_failed_reaction
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_ndp_failed_reaction(p_novel, gt_novel, class_prob, gt_class_idx)
@@ -158,6 +164,8 @@ class ActivityRecognitionMetrics(ProgramMetrics):
         Returns:
             Accuracy on novely samples
         """
+        from evaluate.metrics import M_accuracy_on_novel
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_accuracy_on_novel(class_prob, gt_class_idx, gt_novel)

--- a/sail_on/api/evaluate/document_transcription.py
+++ b/sail_on/api/evaluate/document_transcription.py
@@ -1,9 +1,6 @@
 """Document Transcription Class for metrics for sail-on."""
 
 from .metrics import ProgramMetrics
-from evaluate.metrics import M_acc, M_num, M_ndp, M_num_stats
-from evaluate.metrics import M_ndp_failed_reaction
-from evaluate.metrics import M_accuracy_on_novel
 
 import numpy as np
 from pandas import DataFrame
@@ -79,6 +76,8 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing top1, top3 accuracy over the test, pre and post novelty.
         """
+        from evaluate.metrics import M_acc
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_acc(
@@ -97,6 +96,7 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Difference between the novelty introduction and predicting change in world.
         """
+        from evaluate.metrics import M_num
         return M_num(p_novel, gt_novel)
 
     def m_num_stats(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -110,6 +110,7 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing indices for novelty introduction and change in world prediction.
         """
+        from evaluate.metrics import M_num_stats
         return M_num_stats(p_novel, gt_novel)
 
     def m_ndp(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -123,6 +124,7 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing novelty detection performance over the test.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel)
 
     def m_ndp_pre(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -137,6 +139,7 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance pre novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="pre_novelty")
 
     def m_ndp_post(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -150,6 +153,7 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance post novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="post_novelty")
 
     def m_ndp_failed_reaction(
@@ -172,6 +176,8 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Dictionary containing TP, FP, TN, FN, top1, top3 accuracy over the test.
         """
+        from evaluate.metrics import M_ndp_failed_reaction
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_ndp_failed_reaction(p_novel, gt_novel, class_prob, gt_class_idx)
@@ -190,6 +196,8 @@ class DocumentTranscriptionMetrics(ProgramMetrics):
         Returns:
             Accuracy on novely samples
         """
+        from evaluate.metrics import M_accuracy_on_novel
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_accuracy_on_novel(class_prob, gt_class_idx, gt_novel)

--- a/sail_on/api/evaluate/image_classification.py
+++ b/sail_on/api/evaluate/image_classification.py
@@ -1,9 +1,6 @@
 """Image Classification Class for metrics for sail-on."""
 
 from .metrics import ProgramMetrics
-from evaluate.metrics import M_acc, M_num, M_ndp, M_num_stats
-from evaluate.metrics import M_ndp_failed_reaction
-from evaluate.metrics import M_accuracy_on_novel
 
 import numpy as np
 from pandas import DataFrame
@@ -52,6 +49,8 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing top1, top3 accuracy over the test, pre and post novelty.
         """
+        from evaluate.metrics import M_acc
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_acc(
@@ -71,6 +70,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Difference between the novelty introduction and predicting change in world.
         """
+        from evaluate.metrics import M_num
         return M_num(p_novel, gt_novel)
 
     def m_num_stats(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -86,6 +86,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing indices for novelty introduction and change in world prediction.
         """
+        from evaluate.metrics import M_num_stats
         return M_num_stats(p_novel, gt_novel)
 
     def m_ndp(
@@ -105,6 +106,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing novelty detection performance over the test.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="full_test")
 
     def m_ndp_pre(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -119,6 +121,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance pre novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="pre_novelty")
 
     def m_ndp_post(self, p_novel: np.ndarray, gt_novel: np.ndarray) -> Dict:
@@ -132,6 +135,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing detection performance post novelty.
         """
+        from evaluate.metrics import M_ndp
         return M_ndp(p_novel, gt_novel, mode="post_novelty")
 
     def m_ndp_failed_reaction(
@@ -160,6 +164,8 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Dictionary containing TP, FP, TN, FN, top1, top3 accuracy over the test.
         """
+        from evaluate.metrics import M_ndp_failed_reaction
+
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()
         return M_ndp_failed_reaction(p_novel, gt_novel, class_prob, gt_class_idx)
@@ -180,6 +186,7 @@ class ImageClassificationMetrics(ProgramMetrics):
         Returns:
             Accuracy on novely samples
         """
+        from evaluate.metrics import M_accuracy_on_novel
 
         class_prob = p_class.iloc[:, range(1, p_class.shape[1])].to_numpy()
         gt_class_idx = gt_class.to_numpy()

--- a/sail_on/api/file_provider.py
+++ b/sail_on/api/file_provider.py
@@ -4,9 +4,6 @@ from .provider import Provider, FileResult
 from .errors import ServerError, ProtocolError, RoundError
 from .constants import ProtocolConstants
 
-from .evaluate.image_classification import ImageClassificationMetrics
-from .evaluate.activity_recognition import ActivityRecognitionMetrics
-from .evaluate.document_transcription import DocumentTranscriptionMetrics
 import pandas as pd
 
 import logging
@@ -827,6 +824,9 @@ class FileProvider(Provider):
 
     def evaluate(self, session_id: str, test_id: str) -> Dict:
         """Perform Kitware developed evaluation code modifed to work in this API"""
+        from .evaluate.image_classification import ImageClassificationMetrics
+        from .evaluate.activity_recognition import ActivityRecognitionMetrics
+        from .evaluate.document_transcription import DocumentTranscriptionMetrics
         
         structure = get_session_info(self.results_folder, session_id)
         protocol = structure["created"]["protocol"]


### PR DESCRIPTION
Remove evaluate as a dependency when not running evaluate api call