### PR TITLE
Revert quotechar to default

### DIFF
--- a/sail_on/api/file_provider.py
+++ b/sail_on/api/file_provider.py
@@ -29,7 +29,7 @@ from cachetools import LRUCache, cached
 @cached(cache=LRUCache(maxsize=32))
 def read_gt_csv_file(file_location):
     with open(file_location, "r") as f:
-        csv_reader = csv.reader(f, delimiter=",", quotechar='|')
+        csv_reader = csv.reader(f, delimiter=",")
         return [x for x in csv_reader][1:]
 
 @cached(cache=LRUCache(maxsize=128))
@@ -196,7 +196,6 @@ def get_classification_feedback(
 
     ground_truth = read_feedback_file(read_gt_csv_file(gt_file), feedback_ids, metadata,
                                       check_constrained= feedback_ids is None or len(feedback_ids) == 0)
-
     return {
         x: min(int(ground_truth[x][metadata["columns"][0]]), metadata["known_classes"]) 
         for x in ground_truth.keys()


### PR DESCRIPTION
This PR reverts the quote char to "," from "|". Without "," as quotechar, the feedback api isn't able to parse https://github.com/darpa-sail-on/sail-on-client/blob/master/tests/data/OND/transcripts/OND.0.90001.8714062_single_df.csv#L5 correctly. When quotechar was changed, the last comma in the text causes "lines_fixed" to be the detection column and that crashes the int cast in https://github.com/darpa-sail-on/Sail-On-API/blob/master/sail_on/api/file_provider.py#L201