### PR TITLE
Update description to be single line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    description="""Framework for deploying and evaluating novelty detection
-                    algorithms for DARPA Sail-On.""",
+    description="""Framework for deploying and evaluating novelty detection algorithms for DARPA Sail-On.""",
     long_description=readme + "\n\n" + history,
     include_package_data=True,
     name="sail-on",


### PR DESCRIPTION
This PR changes the description to be single line since https://github.com/pypa/setuptools/issues/1390 would cause `pip install` to fail.