### PR TITLE
Fix: Limited flask's version to those which do not break the used api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask>=1.1.2
+flask>=1.1.2,<2.0
 importlib-metadata>=1.6.0
 requests>=2.23.0
 requests_toolbelt>=0.9.1


### PR DESCRIPTION
The current `requirements.txt` doesn't bound the version of `flask`, and a newer version changes its API regarding the `request.json` property, which, if the request does not contain JSON, will raise an exception.